### PR TITLE
Add yb-voyager@0rc2.2025.8.1 and debezium@0rc2.2.5.2-0rc2.2025.8.1

### DIFF
--- a/Formula/debezium@0rc2.2.5.2-2025.8.1.rb
+++ b/Formula/debezium@0rc2.2.5.2-2025.8.1.rb
@@ -1,0 +1,14 @@
+class DebeziumAT0rc2252202581 < Formula
+    desc "Debezium is an open source distributed platform for change data capture"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc2.2025.8.1/debezium-server.tar.gz"
+    version "0rc2.2.5.2-2025.8.1"
+    sha256 "c6d13c7edf42632d9a44826cb94125b920f73806a823e9855ea0a29a663d4177"
+    license "Apache-2.0"
+
+    def install
+        ENV.deparallelize
+        (prefix/"debezium-server").mkdir
+        cp_r ".", prefix/"debezium-server"
+    end
+end

--- a/Formula/yb-voyager@0rc2.2025.8.1.rb
+++ b/Formula/yb-voyager@0rc2.2025.8.1.rb
@@ -1,0 +1,40 @@
+class YbVoyagerAT0rc2202581 < Formula
+    desc "YugabyteDB's migration tool"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://github.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/v0rc2.2025.8.1.tar.gz"
+    sha256 "7d8f93431bf23d050e210cf4e41de68e6924f2cfd5d0378e928645974da2e171"
+    version "0rc2.2025.8.1"
+    license "Apache-2.0"
+    depends_on "go" => :build
+    depends_on "postgresql@17"
+    depends_on "sqlite"
+    depends_on "yugabyte/tap/debezium@0rc2.2.5.2-2025.8.1"
+    
+    def install
+        ENV.deparallelize
+        Dir.chdir("yb-voyager") do
+            system "go", "build"
+            bin.install "yb-voyager"
+        end
+        Dir.chdir("yb-voyager/src/srcdb/data") do
+            (prefix/"etc/").mkdir
+            (prefix/"etc/yb-voyager/").mkdir
+            cp_r "pg_dump-args.ini", prefix/"etc/yb-voyager/pg_dump-args.ini"
+            cp_r "gather-assessment-metadata", prefix/"etc/yb-voyager/"
+        end
+        Dir.chdir("guardrails-scripts") do
+            (prefix/"opt/").mkdir
+            (prefix/"opt/yb-voyager").mkdir
+            (prefix/"opt/yb-voyager/guardrails-scripts").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/guardrails-scripts"
+        end
+        Dir.chdir("yb-voyager/config-templates") do
+            (prefix/"opt/yb-voyager/config-templates").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/config-templates"
+        end
+    end
+
+    test do
+        system "#{bin}/yb-voyager", "version"
+    end
+end


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@0rc2.2025.8.1
- debezium@0rc2.2.5.2-0rc2.2025.8.1

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 119
- Triggered by: pgupta@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/119/