### PR TITLE
Add yb-voyager@0rc1.2025.8.2 and debezium@0rc1.2.5.2-0rc1.2025.8.2

### DIFF
--- a/Formula/debezium@0rc1.2.5.2-2025.8.2.rb
+++ b/Formula/debezium@0rc1.2.5.2-2025.8.2.rb
@@ -1,0 +1,14 @@
+class DebeziumAT0rc1252202582 < Formula
+    desc "Debezium is an open source distributed platform for change data capture"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2025.8.2/debezium-server.tar.gz"
+    version "0rc1.2.5.2-2025.8.2"
+    sha256 "0c21518257531c50bdc47387e6a5699687964e84be6c91c923070219a9869a2b"
+    license "Apache-2.0"
+
+    def install
+        ENV.deparallelize
+        (prefix/"debezium-server").mkdir
+        cp_r ".", prefix/"debezium-server"
+    end
+end

--- a/Formula/yb-voyager@0rc1.2025.8.2.rb
+++ b/Formula/yb-voyager@0rc1.2025.8.2.rb
@@ -1,0 +1,40 @@
+class YbVoyagerAT0rc1202582 < Formula
+    desc "YugabyteDB's migration tool"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://github.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/v0rc1.2025.8.2.tar.gz"
+    sha256 "b624e3ae05324bc5fb4c0bcd5924894e0d5a37e01e21e4bbcca5abacf78cc9cc"
+    version "0rc1.2025.8.2"
+    license "Apache-2.0"
+    depends_on "go" => :build
+    depends_on "postgresql@17"
+    depends_on "sqlite"
+    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2025.8.2"
+    
+    def install
+        ENV.deparallelize
+        Dir.chdir("yb-voyager") do
+            system "go", "build"
+            bin.install "yb-voyager"
+        end
+        Dir.chdir("yb-voyager/src/srcdb/data") do
+            (prefix/"etc/").mkdir
+            (prefix/"etc/yb-voyager/").mkdir
+            cp_r "pg_dump-args.ini", prefix/"etc/yb-voyager/pg_dump-args.ini"
+            cp_r "gather-assessment-metadata", prefix/"etc/yb-voyager/"
+        end
+        Dir.chdir("guardrails-scripts") do
+            (prefix/"opt/").mkdir
+            (prefix/"opt/yb-voyager").mkdir
+            (prefix/"opt/yb-voyager/guardrails-scripts").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/guardrails-scripts"
+        end
+        Dir.chdir("yb-voyager/config-templates") do
+            (prefix/"opt/yb-voyager/config-templates").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/config-templates"
+        end
+    end
+
+    test do
+        system "#{bin}/yb-voyager", "version"
+    end
+end


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@0rc1.2025.8.2
- debezium@0rc1.2.5.2-0rc1.2025.8.2

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 122
- Triggered by: pgupta@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/122/