### PR TITLE
Add yb-voyager@2025.9.1 and debezium@2.5.2-2025.9.1

### DIFF
--- a/Aliases/debezium
+++ b/Aliases/debezium
@@ -1,1 +1,1 @@
-../Formula/debezium@2.5.2-2025.8.2.rb
+../Formula/debezium@2.5.2-2025.9.1.rb

--- a/Aliases/yb-voyager
+++ b/Aliases/yb-voyager
@@ -1,1 +1,1 @@
-../Formula/yb-voyager@2025.8.2.rb
+../Formula/yb-voyager@2025.9.1.rb

--- a/Formula/debezium@2.5.2-2025.9.1.rb
+++ b/Formula/debezium@2.5.2-2025.9.1.rb
@@ -1,9 +1,9 @@
-class DebeziumAT0rc1252202591 < Formula
+class DebeziumAT252202591 < Formula
     desc "Debezium is an open source distributed platform for change data capture"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2025.9.1/debezium-server.tar.gz"
-    version "0rc1.2.5.2-2025.9.1"
-    sha256 "04ca1e60bdfd36e15ac7002202d51bf2da3b01b22cdfe059aefee14b0d2f0568"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv2025.9.1/debezium-server.tar.gz"
+    version "2.5.2-2025.9.1"
+    sha256 "170d11758ded7bf0daeda3874e8c24a035ed4caac10c3a15c30cc947ce1c36dc"
     license "Apache-2.0"
 
     def install

--- a/Formula/yb-voyager@2025.9.1.rb
+++ b/Formula/yb-voyager@2025.9.1.rb
@@ -1,14 +1,14 @@
-class YbVoyagerAT0rc1202591 < Formula
+class YbVoyagerAT202591 < Formula
     desc "YugabyteDB's migration tool"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://github.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/v0rc1.2025.9.1.tar.gz"
-    sha256 "54622ab33d597d9345f5d527d0d4e6ba4509a44e830617749c7faba81f7ccba1"
-    version "0rc1.2025.9.1"
+    url "https://github.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/v2025.9.1.tar.gz"
+    sha256 "70697cfaa44d8abbbe030e13707e5385057f7ea8cbee1f7a47176c18a58eaa62"
+    version "2025.9.1"
     license "Apache-2.0"
     depends_on "go" => :build
     depends_on "postgresql@17"
     depends_on "sqlite"
-    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2025.9.1"
+    depends_on "yugabyte/tap/debezium@2.5.2-2025.9.1"
     
     def install
         ENV.deparallelize


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@2025.9.1
- debezium@2.5.2-2025.9.1

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 129
- Triggered by: amakala@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/129/