### PR TITLE
Add yb-voyager@2025.9.2 and debezium@2.5.2-2025.9.2

### DIFF
--- a/Aliases/debezium
+++ b/Aliases/debezium
@@ -1,1 +1,1 @@
-../Formula/debezium@2.5.2-2025.9.1.rb
+../Formula/debezium@2.5.2-2025.9.2.rb

--- a/Aliases/yb-voyager
+++ b/Aliases/yb-voyager
@@ -1,1 +1,1 @@
-../Formula/yb-voyager@2025.9.1.rb
+../Formula/yb-voyager@2025.9.2.rb

--- a/Formula/debezium@2.5.2-2025.9.2.rb
+++ b/Formula/debezium@2.5.2-2025.9.2.rb
@@ -1,9 +1,9 @@
-class DebeziumAT0rc1252202592 < Formula
+class DebeziumAT252202592 < Formula
     desc "Debezium is an open source distributed platform for change data capture"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2025.9.2/debezium-server.tar.gz"
-    version "0rc1.2.5.2-2025.9.2"
-    sha256 "72d65f86ec08b11acf5de56371148ececba5023177b70140b8ac2d3074dc9215"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv2025.9.2/debezium-server.tar.gz"
+    version "2.5.2-2025.9.2"
+    sha256 "37cbd970cfaced072d26ba92c05960594e4f647d896d6bc8a3e580ac206b7805"
     license "Apache-2.0"
 
     def install

--- a/Formula/yb-voyager@2025.9.2.rb
+++ b/Formula/yb-voyager@2025.9.2.rb
@@ -1,14 +1,14 @@
-class YbVoyagerAT0rc1202592 < Formula
+class YbVoyagerAT202592 < Formula
     desc "YugabyteDB's migration tool"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v0rc1.2025.9.2.tar.gz"
-    sha256 "7ad1252b2d0b26a53a6b8d05bac7cec7503ce7f426de90670ac3c9eb3271f71a"
-    version "0rc1.2025.9.2"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v2025.9.2.tar.gz"
+    sha256 "c378d5b564f225828c6a8df6b955713562d91c84eec45f147852d1afbad5f4d7"
+    version "2025.9.2"
     license "Apache-2.0"
     depends_on "go" => :build
     depends_on "postgresql@17"
     depends_on "sqlite"
-    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2025.9.2"
+    depends_on "yugabyte/tap/debezium@2.5.2-2025.9.2"
     
     def install
         ENV.deparallelize


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@2025.9.2
- debezium@2.5.2-2025.9.2

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 133
- Triggered by: sgahlot@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/133/