### PR TITLE
Add yb-voyager@0rc1.2025.9.3-b002 and debezium@0rc1.2.5.2-0rc1.2025.9.3-b002

### DIFF
--- a/Formula/debezium@0rc1.2.5.2-2025.9.3-b002.rb
+++ b/Formula/debezium@0rc1.2.5.2-2025.9.3-b002.rb
@@ -1,0 +1,14 @@
+class DebeziumAT0rc1252202593b002 < Formula
+    desc "Debezium is an open source distributed platform for change data capture"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2025.9.3-b002/debezium-server.tar.gz"
+    version "0rc1.2.5.2-2025.9.3-b002"
+    sha256 "b0890c2e88f18cabe8258235283c9a5adb90c6d909e350ddade6016cc9f4779e"
+    license "Apache-2.0"
+
+    def install
+        ENV.deparallelize
+        (prefix/"debezium-server").mkdir
+        cp_r ".", prefix/"debezium-server"
+    end
+end

--- a/Formula/yb-voyager@0rc1.2025.9.3-b002.rb
+++ b/Formula/yb-voyager@0rc1.2025.9.3-b002.rb
@@ -1,0 +1,40 @@
+class YbVoyagerAT0rc1202593b002 < Formula
+    desc "YugabyteDB's migration tool"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v0rc1.2025.9.3-b002.tar.gz"
+    sha256 "7e26c3ab22d0d34a283f6bea204fb63043b822cad203b70a7af35507229dcad7"
+    version "0rc1.2025.9.3-b002"
+    license "Apache-2.0"
+    depends_on "go" => :build
+    depends_on "postgresql@17"
+    depends_on "sqlite"
+    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2025.9.3-b002"
+    
+    def install
+        ENV.deparallelize
+        Dir.chdir("yb-voyager") do
+            system "go", "build"
+            bin.install "yb-voyager"
+        end
+        Dir.chdir("yb-voyager/src/srcdb/data") do
+            (prefix/"etc/").mkdir
+            (prefix/"etc/yb-voyager/").mkdir
+            cp_r "pg_dump-args.ini", prefix/"etc/yb-voyager/pg_dump-args.ini"
+            cp_r "gather-assessment-metadata", prefix/"etc/yb-voyager/"
+        end
+        Dir.chdir("guardrails-scripts") do
+            (prefix/"opt/").mkdir
+            (prefix/"opt/yb-voyager").mkdir
+            (prefix/"opt/yb-voyager/guardrails-scripts").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/guardrails-scripts"
+        end
+        Dir.chdir("yb-voyager/config-templates") do
+            (prefix/"opt/yb-voyager/config-templates").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/config-templates"
+        end
+    end
+
+    test do
+        system "#{bin}/yb-voyager", "version"
+    end
+end


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@0rc1.2025.9.3-b002
- debezium@0rc1.2.5.2-0rc1.2025.9.3-b002

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 134
- Triggered by: ssinghal@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/134/