### PR TITLE
Add yb-voyager@2025.9.3 and debezium@2.5.2-2025.9.3

### DIFF
--- a/Aliases/debezium
+++ b/Aliases/debezium
@@ -1,1 +1,1 @@
-../Formula/debezium@2.5.2-2025.9.2.rb
+../Formula/debezium@2.5.2-2025.9.3.rb

--- a/Aliases/yb-voyager
+++ b/Aliases/yb-voyager
@@ -1,1 +1,1 @@
-../Formula/yb-voyager@2025.9.2.rb
+../Formula/yb-voyager@2025.9.3.rb

--- a/Formula/debezium@2.5.2-2025.9.3.rb
+++ b/Formula/debezium@2.5.2-2025.9.3.rb
@@ -1,0 +1,14 @@
+class DebeziumAT252202593 < Formula
+    desc "Debezium is an open source distributed platform for change data capture"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv2025.9.3/debezium-server.tar.gz"
+    version "2.5.2-2025.9.3"
+    sha256 "dd23f764a44fb116aa8186540fbf517de6093e5e552b584212bcc8374d451176"
+    license "Apache-2.0"
+
+    def install
+        ENV.deparallelize
+        (prefix/"debezium-server").mkdir
+        cp_r ".", prefix/"debezium-server"
+    end
+end

--- a/Formula/yb-voyager@2025.9.3.rb
+++ b/Formula/yb-voyager@2025.9.3.rb
@@ -1,0 +1,40 @@
+class YbVoyagerAT202593 < Formula
+    desc "YugabyteDB's migration tool"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v2025.9.3.tar.gz"
+    sha256 "afa18733c33e3165ffb1735617e129c4c2a4b95deb4a13c1f6614dda91d9b2b4"
+    version "2025.9.3"
+    license "Apache-2.0"
+    depends_on "go" => :build
+    depends_on "postgresql@17"
+    depends_on "sqlite"
+    depends_on "yugabyte/tap/debezium@2.5.2-2025.9.3"
+    
+    def install
+        ENV.deparallelize
+        Dir.chdir("yb-voyager") do
+            system "go", "build"
+            bin.install "yb-voyager"
+        end
+        Dir.chdir("yb-voyager/src/srcdb/data") do
+            (prefix/"etc/").mkdir
+            (prefix/"etc/yb-voyager/").mkdir
+            cp_r "pg_dump-args.ini", prefix/"etc/yb-voyager/pg_dump-args.ini"
+            cp_r "gather-assessment-metadata", prefix/"etc/yb-voyager/"
+        end
+        Dir.chdir("guardrails-scripts") do
+            (prefix/"opt/").mkdir
+            (prefix/"opt/yb-voyager").mkdir
+            (prefix/"opt/yb-voyager/guardrails-scripts").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/guardrails-scripts"
+        end
+        Dir.chdir("yb-voyager/config-templates") do
+            (prefix/"opt/yb-voyager/config-templates").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/config-templates"
+        end
+    end
+
+    test do
+        system "#{bin}/yb-voyager", "version"
+    end
+end


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@2025.9.3
- debezium@2.5.2-2025.9.3

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 136
- Triggered by: ssinghal@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/136/