### PR TITLE
Add yb-voyager@0rc1.2026.4.2 and debezium@0rc1.2.5.2-0rc1.2026.4.2

### DIFF
--- a/Formula/debezium@0rc1.2.5.2-2026.4.2.rb
+++ b/Formula/debezium@0rc1.2.5.2-2026.4.2.rb
@@ -1,0 +1,14 @@
+class DebeziumAT0rc1252202642 < Formula
+    desc "Debezium is an open source distributed platform for change data capture"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2026.4.2/debezium-server.tar.gz"
+    version "0rc1.2.5.2-2026.4.2"
+    sha256 "431de0b5469018f7055bb6d1371e159b19cca366340cc4e76ed78cb9644d9122"
+    license "Apache-2.0"
+
+    def install
+        ENV.deparallelize
+        (prefix/"debezium-server").mkdir
+        cp_r ".", prefix/"debezium-server"
+    end
+end

--- a/Formula/yb-voyager@0rc1.2026.4.2.rb
+++ b/Formula/yb-voyager@0rc1.2026.4.2.rb
@@ -1,0 +1,40 @@
+class YbVoyagerAT0rc1202642 < Formula
+    desc "YugabyteDB's migration tool"
+    homepage "https://github.com/yugabyte/yb-voyager/"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v0rc1.2026.4.2.tar.gz"
+    sha256 "9ce2f70ad3de9e417175370552a88ad2892857a7a819d4ce5fc3ea62e479bf00"
+    version "0rc1.2026.4.2"
+    license "Apache-2.0"
+    depends_on "go@1.24" => :build
+    depends_on "postgresql@17"
+    depends_on "sqlite"
+    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2026.4.2"
+    
+    def install
+        ENV.deparallelize
+        Dir.chdir("yb-voyager") do
+            system "go", "build", "-trimpath"
+            bin.install "yb-voyager"
+        end
+        Dir.chdir("yb-voyager/src/srcdb/data") do
+            (prefix/"etc/").mkdir
+            (prefix/"etc/yb-voyager/").mkdir
+            cp_r "pg_dump-args.ini", prefix/"etc/yb-voyager/pg_dump-args.ini"
+            cp_r "gather-assessment-metadata", prefix/"etc/yb-voyager/"
+        end
+        Dir.chdir("guardrails-scripts") do
+            (prefix/"opt/").mkdir
+            (prefix/"opt/yb-voyager").mkdir
+            (prefix/"opt/yb-voyager/guardrails-scripts").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/guardrails-scripts"
+        end
+        Dir.chdir("yb-voyager/config-templates") do
+            (prefix/"opt/yb-voyager/config-templates").mkdir
+            cp_r ".", prefix/"opt/yb-voyager/config-templates"
+        end
+    end
+
+    test do
+        system "#{bin}/yb-voyager", "version"
+    end
+end


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@0rc1.2026.4.2
- debezium@0rc1.2.5.2-0rc1.2026.4.2

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 172
- Triggered by: ameya.kasture@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/172/