### PR TITLE
Add yb-voyager@2026.4.2 and debezium@2.5.2-2026.4.2

### DIFF
--- a/Aliases/debezium
+++ b/Aliases/debezium
@@ -1,1 +1,1 @@
-../Formula/debezium@2.5.2-2026.4.1.rb
+../Formula/debezium@2.5.2-2026.4.2.rb

--- a/Aliases/yb-voyager
+++ b/Aliases/yb-voyager
@@ -1,1 +1,1 @@
-../Formula/yb-voyager@2026.4.1.rb
+../Formula/yb-voyager@2026.4.2.rb

--- a/Formula/debezium@2.5.2-2026.4.2.rb
+++ b/Formula/debezium@2.5.2-2026.4.2.rb
@@ -1,9 +1,9 @@
-class DebeziumAT0rc1252202642 < Formula
+class DebeziumAT252202642 < Formula
     desc "Debezium is an open source distributed platform for change data capture"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2026.4.2/debezium-server.tar.gz"
-    version "0rc1.2.5.2-2026.4.2"
-    sha256 "431de0b5469018f7055bb6d1371e159b19cca366340cc4e76ed78cb9644d9122"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv2026.4.2/debezium-server.tar.gz"
+    version "2.5.2-2026.4.2"
+    sha256 "8e64310580035afe0c10f840a34f0eb9b60f272c1a150336e197c497f3c2f275"
     license "Apache-2.0"
 
     def install

--- a/Formula/yb-voyager@2026.4.2.rb
+++ b/Formula/yb-voyager@2026.4.2.rb
@@ -1,14 +1,14 @@
-class YbVoyagerAT0rc1202642 < Formula
+class YbVoyagerAT202642 < Formula
     desc "YugabyteDB's migration tool"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v0rc1.2026.4.2.tar.gz"
-    sha256 "9ce2f70ad3de9e417175370552a88ad2892857a7a819d4ce5fc3ea62e479bf00"
-    version "0rc1.2026.4.2"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v2026.4.2.tar.gz"
+    sha256 "e37557c2c876d0cc6f96e3782eab1e169660cade7abae3327dd3f1c7c5adacd3"
+    version "2026.4.2"
     license "Apache-2.0"
     depends_on "go@1.24" => :build
     depends_on "postgresql@17"
     depends_on "sqlite"
-    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2026.4.2"
+    depends_on "yugabyte/tap/debezium@2.5.2-2026.4.2"
     
     def install
         ENV.deparallelize


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@2026.4.2
- debezium@2.5.2-2026.4.2

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 173
- Triggered by: ameya.kasture@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/173/