### PR TITLE
Add yb-voyager@2026.5.2 and debezium@2.5.2-2026.5.2

### DIFF
--- a/Aliases/debezium
+++ b/Aliases/debezium
@@ -1,1 +1,1 @@
-../Formula/debezium@2.5.2-2026.5.1.rb
+../Formula/debezium@2.5.2-2026.5.2.rb

--- a/Aliases/yb-voyager
+++ b/Aliases/yb-voyager
@@ -1,1 +1,1 @@
-../Formula/yb-voyager@2026.5.1.rb
+../Formula/yb-voyager@2026.5.2.rb

--- a/Formula/debezium@2.5.2-2026.5.2.rb
+++ b/Formula/debezium@2.5.2-2026.5.2.rb
@@ -1,9 +1,9 @@
-class DebeziumAT0rc1252202652 < Formula
+class DebeziumAT252202652 < Formula
     desc "Debezium is an open source distributed platform for change data capture"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2026.5.2/debezium-server.tar.gz"
-    version "0rc1.2.5.2-2026.5.2"
-    sha256 "d511cc9eb2c6a11590d4fa6b20c60e6cfe3c28521e52e607182627637fd16fef"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv2026.5.2/debezium-server.tar.gz"
+    version "2.5.2-2026.5.2"
+    sha256 "d708ed719b779c5ecba8e39bcc2df912a4e9a58d76e927dc7e2ee4721f8e69ac"
     license "Apache-2.0"
 
     def install

--- a/Formula/yb-voyager@2026.5.2.rb
+++ b/Formula/yb-voyager@2026.5.2.rb
@@ -1,14 +1,14 @@
-class YbVoyagerAT0rc1202652 < Formula
+class YbVoyagerAT202652 < Formula
     desc "YugabyteDB's migration tool"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v0rc1.2026.5.2.tar.gz"
-    sha256 "67ba338d23140daadec894ba09d089b0b375a5e1488be9300edace1856e341ea"
-    version "0rc1.2026.5.2"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v2026.5.2.tar.gz"
+    sha256 "1731cdc6dd859f35f2ec43d9d967d743f54ff5ff89f3fe0eb96416f588dc9dfc"
+    version "2026.5.2"
     license "Apache-2.0"
     depends_on "go@1.24" => :build
     depends_on "postgresql@17"
     depends_on "sqlite"
-    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2026.5.2"
+    depends_on "yugabyte/tap/debezium@2.5.2-2026.5.2"
     
     def install
         ENV.deparallelize


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@2026.5.2
- debezium@2.5.2-2026.5.2

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 178
- Triggered by: amakala@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/178/