### PR TITLE
Add yb-voyager@2026.7.1 and debezium@2.5.2-2026.7.1

### DIFF
--- a/Aliases/debezium
+++ b/Aliases/debezium
@@ -1,1 +1,1 @@
-../Formula/debezium@2.5.2-2026.6.2.rb
+../Formula/debezium@2.5.2-2026.7.1.rb

--- a/Aliases/yb-voyager
+++ b/Aliases/yb-voyager
@@ -1,1 +1,1 @@
-../Formula/yb-voyager@2026.6.2.rb
+../Formula/yb-voyager@2026.7.1.rb

--- a/Formula/debezium@2.5.2-2026.7.1.rb
+++ b/Formula/debezium@2.5.2-2026.7.1.rb
@@ -1,9 +1,9 @@
-class DebeziumAT0rc1252202671 < Formula
+class DebeziumAT252202671 < Formula
     desc "Debezium is an open source distributed platform for change data capture"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2026.7.1/debezium-server.tar.gz"
-    version "0rc1.2.5.2-2026.7.1"
-    sha256 "29d5dab425e20a82d373ffda2704fa052fff6ecbf6b3ef9bb10462fa3ed38578"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv2026.7.1/debezium-server.tar.gz"
+    version "2.5.2-2026.7.1"
+    sha256 "4038b60af0c04c7f2a25c0326cd236f8298a0a743d0ca0bd32af5cbcd2aef091"
     license "Apache-2.0"
 
     def install

--- a/Formula/yb-voyager@2026.7.1.rb
+++ b/Formula/yb-voyager@2026.7.1.rb
@@ -1,14 +1,14 @@
-class YbVoyagerAT0rc1202671 < Formula
+class YbVoyagerAT202671 < Formula
     desc "YugabyteDB's migration tool"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v0rc1.2026.7.1.tar.gz"
-    sha256 "6f32eccf0bdfeb5ef3773aa9210780bb98d4f72efd3208f46e0e5c391ce94bee"
-    version "0rc1.2026.7.1"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v2026.7.1.tar.gz"
+    sha256 "963787eab7af2cdcf3de7e817f6c52e3f94e48507979e3749f4f6e64ec9626c4"
+    version "2026.7.1"
     license "Apache-2.0"
     depends_on "go@1.24" => :build
     depends_on "postgresql@17"
     depends_on "sqlite"
-    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2026.7.1"
+    depends_on "yugabyte/tap/debezium@2.5.2-2026.7.1"
     
     def install
         ENV.deparallelize


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@2026.7.1
- debezium@2.5.2-2026.7.1

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 184
- Triggered by: pgupta@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/184/