### PR TITLE
Add yb-voyager@2026.7.2 and debezium@2.5.2-2026.7.2

### DIFF
--- a/Aliases/debezium
+++ b/Aliases/debezium
@@ -1,1 +1,1 @@
-../Formula/debezium@2.5.2-2026.7.1.rb
+../Formula/debezium@2.5.2-2026.7.2.rb

--- a/Aliases/yb-voyager
+++ b/Aliases/yb-voyager
@@ -1,1 +1,1 @@
-../Formula/yb-voyager@2026.7.1.rb
+../Formula/yb-voyager@2026.7.2.rb

--- a/Formula/debezium@2.5.2-2026.7.2.rb
+++ b/Formula/debezium@2.5.2-2026.7.2.rb
@@ -1,9 +1,9 @@
-class DebeziumAT0rc1252202672 < Formula
+class DebeziumAT252202672 < Formula
     desc "Debezium is an open source distributed platform for change data capture"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv0rc1.2026.7.2/debezium-server.tar.gz"
-    version "0rc1.2.5.2-2026.7.2"
-    sha256 "2e24017b9f0cc7557cda4b4946e17a75d2566337b4e9f05c214a540ac2e4c0e4"
+    url "https://github.com/yugabyte/yb-voyager/releases/download/yb-voyager%2Fv2026.7.2/debezium-server.tar.gz"
+    version "2.5.2-2026.7.2"
+    sha256 "e4a538f38b2fcf82bd65241ba7db4618e01186051ff5a9807a571016e092a868"
     license "Apache-2.0"
 
     def install

--- a/Formula/yb-voyager@2026.7.2.rb
+++ b/Formula/yb-voyager@2026.7.2.rb
@@ -1,14 +1,14 @@
-class YbVoyagerAT0rc1202672 < Formula
+class YbVoyagerAT202672 < Formula
     desc "YugabyteDB's migration tool"
     homepage "https://github.com/yugabyte/yb-voyager/"
-    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v0rc1.2026.7.2.tar.gz"
-    sha256 "3e6e91861d8285ae80fb9362a141fad2f34664179fc8aa25190c97b0c188530a"
-    version "0rc1.2026.7.2"
+    url "https://software.yugabyte.com/yugabyte/yb-voyager/archive/refs/tags/yb-voyager/brew/v2026.7.2.tar.gz"
+    sha256 "7ed9b374c2af15c0cae7b67c40f60c0be39d8248bf74bb2d106e6d92df7c159e"
+    version "2026.7.2"
     license "Apache-2.0"
     depends_on "go@1.24" => :build
     depends_on "postgresql@17"
     depends_on "sqlite"
-    depends_on "yugabyte/tap/debezium@0rc1.2.5.2-2026.7.2"
+    depends_on "yugabyte/tap/debezium@2.5.2-2026.7.2"
     
     def install
         ENV.deparallelize


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula files for:
- yb-voyager@2026.7.2
- debezium@2.5.2-2026.7.2

## Changes
- Added formula files in Formula/ directory
- Updated aliases in Aliases/ directory (for non-RC releases)
- Generated SHA256 checksums for the release artifacts

## Build Info
- Build Number: 187
- Triggered by: amakala@yugabyte.com
- Jenkins Build: https://jenkins.dev.yugabyte.com/job/users/job/yb-voyager-release/job/voyager-homebrew-release/187/